### PR TITLE
Don't send GPS specific command before recognition

### DIFF
--- a/host/lib/usrp/gps_ctrl.cpp
+++ b/host/lib/usrp/gps_ctrl.cpp
@@ -372,9 +372,6 @@ public:
     _flush(); //get whatever junk is in the rx buffer right now, and throw it away
     _send("HAAAY GUYYYYS\n"); //to elicit a response from the GPSDO
 
-    // try to init LEA-M8F
-    init_lea_m8f();
-
     //wait for _send(...) to return
     sleep(milliseconds(GPSDO_COMMAND_DELAY_MS));
 


### PR DESCRIPTION
LEA M8F should be initialized after recognition, which is indeed the case 
so the first init is not needed and might be harmful for other GPS modules.
